### PR TITLE
Removing string length === 32 check for $device id

### DIFF
--- a/cycleatlanta.org/post/index.php
+++ b/cycleatlanta.org/post/index.php
@@ -78,7 +78,7 @@ elseif ( $version == PROTOCOL_VERSION_4 ) {
 }
 
 // validate device ID
-if ( is_string( $device ) && strlen( $device ) === 32 )
+if ( is_string( $device ) )
 {
 	// try to lookup user by this device ID
 	$user = null;


### PR DESCRIPTION
Android phones generate a 64-bit as a result of Secure.ANDROID_ID, so in TripUploader.java (android cycletracks/cycleatlanta), lines 197-199 SHOULD make a string of length 32, however the string returned by Secure.ANDROID_ID is not guaranteed to be of length 16 and so this line occasionally causes a complete inability to upload for some devices
